### PR TITLE
Dynamically list time points

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const http = axios.create({
+  baseURL: 'https://data.computational-biology.org/api/v1/',
+});
+
+export default http;

--- a/src/pages/VolumePage.vue
+++ b/src/pages/VolumePage.vue
@@ -106,14 +106,14 @@ export default {
     },
     async getTPs() {
       const timepointFolderIDs = this.timepointsIDs;
-      const rootID = '5cf18200ef2e260353a51922'
+      const rootID = '5cf18200ef2e260353a51922';
 
-      const timepointInfo = (await http.get('folder/' + rootID + '/details')).data
+      const timepointInfo = (await http.get(`folder/${rootID}/details`)).data;
       const timepointFolders = (await http.get('folder', {
         params: {
           parentType: 'folder',
           parentId: rootID,
-          limit: timepointInfo.nItems
+          limit: timepointInfo.nItems,
         },
       })).data;
 

--- a/src/pages/VolumePage.vue
+++ b/src/pages/VolumePage.vue
@@ -108,18 +108,18 @@ export default {
     },
     async getTPs () {
       try {
-        let timePointFolderIDs = this.timepointsIDs
+        let timepointFolderIDs = this.timepointsIDs
 
-        const timePointFolders = (await this.http.get('folder', {
+        const timepointFolders = (await this.http.get('folder', {
           params: {
             parentType: 'folder',
             parentId: '5cb56d8cef2e260353a50f04'
           }
         })).data
 
-        for (let i = 0; i < timePointFolders.length; i++) {
-          timePointFolderIDs[timePointFolders[i].name] = timePointFolders[i]._id
-          this.timepoints.push(timePointFolders[i].name)
+        for (let i = 0; i < timepointFolders.length; i++) {
+          timepointFolderIDs[timepointFolders[i].name] = timepointFolders[i]._id
+          this.timepoints.push(timepointFolders[i].name)
         }
       } catch (err) {
         console.error(err)
@@ -136,13 +136,14 @@ export default {
           const path = 'item/' + dataItem._id + '/files'
           return this.http.get(path)
         })
-        const dataFilesResponse = await Promise.all(dataFilesPromises)
-        const dataFiles = dataFilesResponse.map((dataFileResponse) => dataFileResponse.data)
+        const dataFilesResponses = await Promise.all(dataFilesPromises)
+        const dataFiles = dataFilesResponses.map((dataFileResponse) => dataFileResponse.data)
 
         let dataFilesIDs = {}
         for (let i = 0; i < dataFiles.length; i++) {
-          var fullname = dataFiles[i][0].name
-          dataFilesIDs[fullname.substring(0, fullname.length - 8)] = dataFiles[i][0]._id
+          const dataFile = dataFiles[i][0]
+          var fullname = dataFile.name
+          dataFilesIDs[fullname.substring(0, fullname.length - 8)] = dataFile._id
         }
         return dataFilesIDs
       } catch (err) {

--- a/src/pages/VolumePage.vue
+++ b/src/pages/VolumePage.vue
@@ -106,11 +106,14 @@ export default {
     },
     async getTPs() {
       const timepointFolderIDs = this.timepointsIDs;
+      const rootID = '5cf18200ef2e260353a51922'
 
+      const timepointInfo = (await http.get('folder/' + rootID + '/details')).data
       const timepointFolders = (await http.get('folder', {
         params: {
           parentType: 'folder',
-          parentId: '5cb56d8cef2e260353a50f04',
+          parentId: rootID,
+          limit: timepointInfo.nItems
         },
       })).data;
 
@@ -136,7 +139,7 @@ export default {
       for (let i = 0; i < dataFiles.length; i += 1) {
         const dataFile = dataFiles[i][0];
         const fullname = dataFile.name;
-        dataFilesIDs[fullname.substring(0, fullname.length - 8)] = dataFile._id;
+        dataFilesIDs[fullname.substring(0, fullname.indexOf('_'))] = dataFile._id;
       }
       return dataFilesIDs;
     },


### PR DESCRIPTION
dynamically retrieves file id's for time point data

The hard coded ids were replaced with a dynamic system. The new system initially retrieves all the ids of folders in the base folder and figures out which time points have data, displaying those as options in the "select time point" tab. Each of those ids each correspond to a folder holding the data for a single time point. When a time point is selected, the ids of the items inside the folder is retrieved and used to get the ids of the files within those items. Those ids are then returned to be used to load the actual data.