### PR TITLE
VTK Converter and File Uploader

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+requests = "*"
+vtk = "*"
+girder-client = "*"
+
+[requires]
+python_version = "2.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,109 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "890b433d0862d604b633683a9100e86f3ad3b2c892405817233a28eafe75b0ce"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "2.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+            ],
+            "version": "==2019.3.9"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "click": {
+            "hashes": [
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+            ],
+            "version": "==7.0"
+        },
+        "diskcache": {
+            "hashes": [
+                "sha256:99db0eec5c86060b3ae906009d86bb99f70d36a09836606396ae3b237cc92b18",
+                "sha256:f5fa6a2274bc4fc2f1c884034f9ab1cc838054421ff493524732f52cc1174fbc"
+            ],
+            "version": "==3.1.1"
+        },
+        "girder-client": {
+            "hashes": [
+                "sha256:1a9c882b8bce2e8233f572a4df9565c678e5614993e6606cdff04251532cddcb"
+            ],
+            "index": "pypi",
+            "version": "==2.4.0"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+            ],
+            "index": "pypi",
+            "version": "==2.22.0"
+        },
+        "requests-toolbelt": {
+            "hashes": [
+                "sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f",
+                "sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"
+            ],
+            "version": "==0.9.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+            ],
+            "version": "==1.25.3"
+        },
+        "vtk": {
+            "hashes": [
+                "sha256:110dd7d730584b2e8c13e15f1b245d1b5afb9a6e163223e1fb0e775cec818e92",
+                "sha256:28df91add29d9cdd6c49235b2c65e31ab50c8655c56ad1a5914b605e22554d7d",
+                "sha256:34b43d32609d81d94a7122e388f7d6a0883138438484d0ee29158726810f6704",
+                "sha256:44454f9dd6c41f20b904b41e1ac0dd06cc3367952da1a8d8d3074e1a40dce916",
+                "sha256:56e73eeba6402ba497a24ebdbe773cadbf01b9f7c12b3a2e26f8b40f203d718e",
+                "sha256:5c2634afaabd2243c5fbe0f4aa9cff66537cfbcb5d4893e93c31cfce878a413c",
+                "sha256:8c6809a3526c8cf06b921dec06cd672f54baa3a050124f0f19f0adb6cf283aa4",
+                "sha256:cd68246764412e8f6855e8e73772392aa826b9d6c3d59e7544ce22af1ad7dcc8",
+                "sha256:d4d834d29abf98c67a63328c271e82bde3f769cbae295fb91e840bead2298d13",
+                "sha256:e790aed1a776d3682b2c38a5a795a0f46e3043f96ed113a3bbaf7ef5eaaeba08",
+                "sha256:ee17372ded18987480e3e07405f9b36fc4e2a0c1da1503628c4980a3957d7c98"
+            ],
+            "index": "pypi",
+            "version": "==8.1.2"
+        }
+    },
+    "develop": {}
+}

--- a/scripts/vtk_convert.py
+++ b/scripts/vtk_convert.py
@@ -1,0 +1,91 @@
+from vtk import vtkPolyDataReader, vtkStructuredPointsReader, \
+    vtkXMLImageDataWriter, vtkXMLPolyDataWriter
+from girder_client import GirderClient
+import os
+import click
+import re
+
+@click.command()
+@click.option('--inputfolderid', required=True, prompt=True, help='Source Folder ID')
+@click.option('--outputfolderid', required=True, prompt=True, help='Destination Folder ID')
+@click.option('--apikey', required=True, prompt=True, help='API Key from Girder')
+@click.option('--hostname', default='https://data.computational-biology.org/api/v1/', prompt=True, help='URL, make sure to include /api/v1/ at the end')
+def main(inputfolderid, outputfolderid, apikey, hostname):
+  gc = GirderClient(apiUrl=hostname)
+  gc.authenticate(apiKey=apikey)
+
+  def getFiles(itemData):
+    print('getting ' + itemData['name'])
+    dataFiles = gc.get('item/' + itemData['_id'] + '/files')
+    return dataFiles[0]
+
+  def getItems(folderData):
+    folderInfo = gc.get('folder/' + folderData['_id'] + '/details')
+    folderItems = gc.get('item',
+      parameters={
+        'folderId': folderData['_id'],
+        'limit': folderInfo['nItems']
+      })
+    return map(getFiles, folderItems)
+
+  gmsFolders = gc.get('folder',
+    parameters={
+      'parentType': 'folder',
+      'parentId': inputfolderid,
+    })
+
+  gmsFileNames = map(getItems, gmsFolders)
+
+  for row in gmsFileNames:
+    for elem in row:
+      oldName = elem['name']
+      print('dowloading ' + oldName)
+      try:
+        gc.downloadFile(elem['_id'], os.path.abspath(oldName))
+
+        reader = vtkPolyDataReader()
+        writer = vtkXMLPolyDataWriter()
+        fileType = ''
+        if re.search("^geometry_", oldName):
+          reader = vtkStructuredPointsReader()
+          reader.ReadAllScalarsOn()
+          writer = vtkXMLImageDataWriter()
+          fileType = 'geometry_'
+        elif re.search("^spore_", oldName):
+          fileType = 'spore_'
+        elif re.search("^macrophage_", oldName):
+          fileType = 'macrophage_'
+        else:
+          raise Exception('Invalid File: {}'.format(oldName))
+
+        reader.SetFileName(oldName)
+        reader.Update()
+        data = reader.GetOutput()
+
+        end = oldName[len(fileType):]
+        num = '00' + end[:len(end) - 4]
+        fixed = num[len(num) - 3:]
+        name = fileType + fixed + '.vti'
+        print('writing ' + name)
+
+        writer.SetFileName(name)
+        writer.SetCompressorTypeToZLib()
+        writer.SetInputData(data)
+        writer.Update()
+
+        timepointFolder = gc.post('folder/',
+          parameters={
+            'parentType': 'folder',
+            'parentId': outputfolderid,
+            'name': fixed,
+            'reuseExisting': True
+          })
+
+        gc.uploadFileToFolder(timepointFolder['_id'], name)
+
+      except girder_client.HttpError:
+        print("ERROR DOWNLOADING")
+        pass
+
+if __name__ == '__main__':
+  main()

--- a/scripts/vtk_convert.py
+++ b/scripts/vtk_convert.py
@@ -12,23 +12,11 @@ import re
 
 gc = None
 
+
 @click.command()
-@click.option(
-    '--input-folder-id',
-    required=True,
-    help='Source Folder ID',
-)
-@click.option(
-    '--output-folder-id',
-    required=True,
-    help='Destination Folder ID',
-)
-@click.option(
-    '--api-key',
-    required=True,
-    prompt=True,
-    help='API Key from Girder',
-)
+@click.option('--input-folder-id', required=True, help='Source Folder ID')
+@click.option('--output-folder-id', required=True, help='Destination Folder ID')
+@click.option('--api-key', required=True, prompt=True, help='API Key from Girder')
 @click.option(
     '--hostname',
     default='https://data.computational-biology.org/api/v1/',
@@ -39,92 +27,78 @@ def main(input_folder_id, output_folder_id, api_key, hostname):
     gc = girder_client.GirderClient(apiUrl=hostname)
     gc.authenticate(apiKey=api_key)
 
-    s = gc.session()
-    s.mount(hostname, HTTPAdapter(max_retries=5))
+    with gc.session() as s:
+        s.mount(hostname, HTTPAdapter(max_retries=5))
 
-    gmsFolders = gc.get(
-        'folder',
-        parameters={
-            'parentType': 'folder',
-            'parentId': input_folder_id,
-        },
-    )
+        gmsFolders = gc.get(
+            'folder', parameters={'parentType': 'folder', 'parentId': input_folder_id}
+        )
 
-    gmsFiles = map(getItems, gmsFolders)
+        gmsFiles = map(getItems, gmsFolders)
 
-    for gms in gmsFiles:
-        for file in gms:
-            oldName = file['name']
-            print(f'downloading {oldName}')
-            try:
-                gc.downloadFile(
-                    file['_id'], os.path.abspath(oldName)
-                )
+        for gms in gmsFiles:
+            for file in gms:
+                oldName = file['name']
+                print(f'downloading {oldName}')
+                try:
+                    gc.downloadFile(file['_id'], os.path.abspath(oldName))
 
-                reader = vtkPolyDataReader()
-                writer = vtkXMLPolyDataWriter()
-                if re.search('^geometry', oldName):
-                    reader = vtkStructuredPointsReader()
-                    reader.ReadAllScalarsOn()
-                    writer = vtkXMLImageDataWriter()
-                    fileType = 'geometry'
-                elif re.search('^spore', oldName):
-                    fileType = 'spore'
-                elif re.search('^macrophage', oldName):
-                    fileType = 'macrophage'
-                else:
-                    raise Exception(
-                        'Invalid File: {}'.format(oldName)
+                    # oldName looks like geometry_0.vtk
+                    nameMatch = re.match(r'^([a-zA-Z]+)_([0-9]+)\.vtk$', oldName)
+                    fileType = nameMatch.group(1)
+                    num = int(nameMatch.group(2))
+
+                    if fileType == 'geometry':
+                        reader = vtkStructuredPointsReader()
+                        reader.ReadAllScalarsOn()
+                        writer = vtkXMLImageDataWriter()
+                    elif fileType == 'spore':
+                        reader = vtkPolyDataReader()
+                        writer = vtkXMLPolyDataWriter()
+                    elif fileType == 'macrophage':
+                        reader = vtkPolyDataReader()
+                        writer = vtkXMLPolyDataWriter()
+                    else:
+                        raise Exception('Invalid File: {}'.format(oldName))
+
+                    reader.SetFileName(oldName)
+                    reader.Update()
+                    data = reader.GetOutput()
+
+                    name = f'{fileType}_{num:03}.vti'
+                    print(f'writing {name}')
+
+                    writer.SetFileName(name)
+                    writer.SetCompressorTypeToZLib()
+                    writer.SetInputData(data)
+                    writer.Update()
+
+                    timepointFolder = gc.post(
+                        'folder/',
+                        parameters={
+                            'parentType': 'folder',
+                            'parentId': output_folder_id,
+                            'name': num,
+                            'reuseExisting': True,
+                        },
                     )
 
-                reader.SetFileName(oldName)
-                reader.Update()
-                data = reader.GetOutput()
+                    gc.uploadFileToFolder(timepointFolder['_id'], name)
 
-                end = oldName[len(fileType):]
-                num = '{:03d}'.format(int(end[1:-4]))
-                name = f'{fileType}_{num}.vti'
-                print(f'writing {name}')
-
-                writer.SetFileName(name)
-                writer.SetCompressorTypeToZLib()
-                writer.SetInputData(data)
-                writer.Update()
-
-                timepointFolder = gc.post(
-                    'folder/',
-                    parameters={
-                        'parentType': 'folder',
-                        'parentId': output_folder_id,
-                        'name': num,
-                        'reuseExisting': True,
-                    },
-                )
-
-                gc.uploadFileToFolder(
-                    timepointFolder['_id'], name
-                )
-
-            except girder_client.HttpError:
-                print('ERROR DOWNLOADING')
+                except girder_client.HttpError:
+                    print('ERROR DOWNLOADING')
 
 
 def getItems(folderData):
-    items = gc.get(
-        'item',
-        parameters={
-            'folderId': folderData['_id'],
-            'limit': 0,
-        },
-    )
+    items = gc.get('item', parameters={'folderId': folderData['_id'], 'limit': 0})
     return map(getFiles, items)
+
 
 def getFiles(item):
     print(f'getting {item["name"]}')
-    files = gc.get(
-        f'item/{item["_id"]}/files'
-    )
+    files = gc.get(f'item/{item["_id"]}/files')
     return files[0]
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Converts VTK to VTI files and uploads those files to Girder.

The python script retrieves the ids of all of the geometry, macrophage, and spore files from folder, based on the ID provided. It assuming they follow a hierarchy like this: root folder > geometry folder > geometry_XXX.vtk items > geometry_XXX.vtk file. Those files are then all downloaded and converted into vti files and uploaded to the provided folder ID and sorts them into a hierarchy like this: root folder > XXX timepoint folder > geometry_XXX.vti item, macrophage_XXX.vti item, spore_XXX.vti item > corresponding file. 