### PR TITLE
Fix linting when the the _"id" property is accessed on Girder data

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,14 @@
             "state"
           ]
         }
+      ],
+      "no-underscore-dangle": [
+        "error",
+        {
+          "allow": [
+            "_id"
+          ]
+        }
       ]
     },
     "parserOptions": {


### PR DESCRIPTION
Normally, the no-underscore-dangle ( https://eslint.org/docs/rules/no-underscore-dangle) ESLint rule prevents a property with leading underscores from being used. Since calls to the Girder API return objects with the "_id" property, this adds an rule exception for this particular identifier.